### PR TITLE
Added workflow for building the Blinky example with AC6, GCC, and LLVM compiler

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -11,7 +11,8 @@
         "arm:tools/kitware/cmake": "^3.28.4",
         "arm:tools/ninja-build/ninja": "^1.12.0",
         "arm:compilers/arm/armclang": "^6.23.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1",        
+        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1",
+        "arm:compilers/arm/llvm-embedded": "19.1.5",
         "arm:debuggers/arm/armdbg": "^6.3.0"
     }
 }

--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -1,0 +1,17 @@
+{
+    "registries": [
+        {
+            "name": "arm",
+            "kind": "artifact",
+            "location": "https://artifacts.tools.arm.com/vcpkg-registry"
+        }
+    ],
+    "requires": {
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.2",
+        "arm:tools/kitware/cmake": "^3.28.4",
+        "arm:tools/ninja-build/ninja": "^1.12.0",
+        "arm:compilers/arm/armclang": "^6.23.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1",        
+        "arm:debuggers/arm/armdbg": "^6.3.0"
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: Build Blinky example
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+        fail-fast: false
+
+    steps:
+      - name: Checkout .ci folder
+        uses: actions/checkout@v4
+        with:
+            sparse-checkout: |
+              .ci
+
+      # https://github.com/ARM-software/cmsis-actions
+      - name: Activate vcpkg
+        uses: ARM-software/cmsis-actions/vcpkg@v1
+        with: 
+          config: "./vcpkg-configuration.json"
+
+      # https://github.com/ARM-software/cmsis-actions
+      - name: Activate Arm tool license
+        uses: ARM-software/cmsis-actions/armlm@v1
+
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+        with:
+          path: ./BSP
+
+      - name: Checkout DFP-Pack-HandsOn
+        uses: actions/checkout@v4
+        with:
+            repository: Open-CMSIS-Pack/DFP-Pack-HandsOn
+            path: ./DFP
+
+      - name: Initialize CMSIS pack root folder
+        run: |
+          cpackget init https://www.keil.com/pack/index.pidx
+          cpackget update-index
+
+      - name: Add local CMSIS packs
+        run: |
+          cpackget add ./BSP/ACME.ACME_BSP.pdsc
+          cpackget add ./DFP/ACME.ACMECM4_DFP.pdsc
+
+      - name: Copy Blinky example to CI/Examples/ folder
+        working-directory: ./
+        run: |
+          mkdir -p ./CI/Examples/Blinky
+          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+
+      - name: Build Blinky AC6 Release
+        if: always()
+        working-directory: ./CI/Examples/Blinky
+        run: |
+          cbuild ./Blinky.csolution.yml --packs --context Blinky.Release+ACME_Board --toolchain AC6 --rebuild --update-rte
+
+      - name: Upload Artifact of the Blinky AC6 build
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Blinky_Release_AC6
+          path: |
+            ./CI/Examples/Blinky/out/Blinky/Release/Blinky.axf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,4 +69,4 @@ jobs:
         with:
           name: Blinky_Release_AC6
           path: |
-            ./CI/Examples/Blinky/out/Blinky/Release/Blinky.axf
+            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.axf            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Activate vcpkg
         uses: ARM-software/cmsis-actions/vcpkg@v1
         with: 
-          config: "./vcpkg-configuration.json"
+          config: "./.ci/vcpkg-configuration.json"
 
       # https://github.com/ARM-software/cmsis-actions
       - name: Activate Arm tool license

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Blinky_Release_AC6
+          name: Blinky_Release_GCC
           path: |
             ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,9 @@ jobs:
         fail-fast: false
         matrix:
           compiler: [ 
-            {name: AC6,  ext: axf},
-            {name: GCC,  ext: elf}
+            {name: AC6,   ext: axf},
+            {name: GCC,   ext: elf},
+            {name: CLANG, ext: elf}
           ]
           build: [ 
             {type: Release},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,4 +69,18 @@ jobs:
         with:
           name: Blinky_Release_AC6
           path: |
-            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.axf            
+            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.axf
+
+      - name: Build Blinky GCC Release
+        if: always()
+        working-directory: ./CI/Examples/Blinky
+        run: |
+          cbuild ./Blinky.csolution.yml --packs --context Blinky.Release+ACME_Board --toolchain GCC --rebuild --update-rte
+
+      - name: Upload Artifact of the Blinky AC6 build
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Blinky_Release_AC6
+          path: |
+            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Blinky example
+name: Example Compile Test
 on:
   workflow_dispatch:
   pull_request:
@@ -12,7 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false
-
+        matrix:
+          compiler: [ 
+            {name: AC6,  ext: axf},
+            {name: GCC,  ext: elf}
+          ]
+          build: [ 
+            {type: Release},
+            {type: Debug}
+          ]
+          
     steps:
       - name: Checkout .ci folder
         uses: actions/checkout@v4
@@ -57,30 +66,16 @@ jobs:
           mkdir -p ./CI/Examples/Blinky
           cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
 
-      - name: Build Blinky AC6 Release
+      - name: Build Blinky ${{ matrix.compiler.name }} ${{ matrix.build.type }}
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --context Blinky.Release+ACME_Board --toolchain AC6 --rebuild --update-rte
+          cbuild ./Blinky.csolution.yml --packs --context Blinky.${{ matrix.build.type }}+ACME_Board --toolchain ${{ matrix.compiler.name }} --rebuild --update-rte
 
-      - name: Upload Artifact of the Blinky AC6 build
+      - name: Upload Artifact of the Blinky ${{ matrix.compiler.name }} ${{ matrix.build.type }} build
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Blinky_Release_AC6
+          name: Blinky_${{ matrix.build.type }}_${{ matrix.compiler.name }}
           path: |
-            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.axf
-
-      - name: Build Blinky GCC Release
-        if: always()
-        working-directory: ./CI/Examples/Blinky
-        run: |
-          cbuild ./Blinky.csolution.yml --packs --context Blinky.Release+ACME_Board --toolchain GCC --rebuild --update-rte
-
-      - name: Upload Artifact of the Blinky AC6 build
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Blinky_Release_GCC
-          path: |
-            ./CI/Examples/Blinky/out/Blinky/ACME_Board/Release/Blinky.elf
+            ./CI/Examples/Blinky/out/Blinky/ACME_Board/${{ matrix.build.type }}/Blinky.${{ matrix.compiler.ext }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         uses: ARM-software/cmsis-actions/vcpkg@v1
         with: 
           config: "./.ci/vcpkg-configuration.json"
+          cache: -${{ matrix.compiler.name }}-${{ matrix.build.type }}           
 
       # https://github.com/ARM-software/cmsis-actions
       - name: Activate Arm tool license

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.7.0
+  created-for: CMSIS-Toolbox@2.6.0
   cdefault:
 
   # List of tested compilers that can be selected
@@ -12,7 +12,7 @@ solution:
 
   # List the packs that define the device and/or board.
   packs:
-    - pack: ARM::CMSIS@6.1.0
+    - pack: ARM::CMSIS
     - pack: ARM::CMSIS-FreeRTOS@^11.1.0
     - pack: ACME::ACMECM4_DFP@^1.0.0
     - pack: ACME::ACME_BSP@^1.0.2

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.7.0
   cdefault:
 
   # List of tested compilers that can be selected
@@ -12,7 +12,7 @@ solution:
 
   # List the packs that define the device and/or board.
   packs:
-    - pack: ARM::CMSIS
+    - pack: ARM::CMSIS@6.1.0
     - pack: ARM::CMSIS-FreeRTOS@^11.1.0
     - pack: ACME::ACMECM4_DFP@^1.0.0
     - pack: ACME::ACME_BSP@^1.0.2
@@ -36,3 +36,4 @@ solution:
   # list related projects
   projects:
     - project: ./Blinky.cproject.yml
+  compiler: AC6


### PR DESCRIPTION
Added workflow for building the Blinky example with AC6, GCC, and LLVM compiler and for the build types Release and Debug.